### PR TITLE
Add RFC: sRGB Color Space setting

### DIFF
--- a/accepted/0007-color-space-srgb.md
+++ b/accepted/0007-color-space-srgb.md
@@ -1,0 +1,33 @@
+# Summary
+
+Add sRGB to "Color Space" output options, and default to sRGB.
+
+# Motivation
+
+There is often confusion around the "Color Space" option for output, and it has several problems.
+
+- We don't actually convert colors between RGB color spaces in OBS. We merely tag the metadata.
+- Rec. 601 output support is weird. x264 tags 601 as "undef" for everything, and jim-nvenc uses the European 625-line variant of 601 attributes.
+- Any PC applications/games that output sRGB are tagged as 601/709, and will be handled incorrectly by color-accurate applications, e.g. old versions of Chrome handled 709 properly before they decided to cheat to save power.
+
+Defaulting to sRGB is probably the least of all evils.
+
+- sRGB is identical to Rec. 709 except for the sRGB transfer function, which can be a free conversion for most GPUs. When represented as YCbCr, it makes sense to transform with Rec. 709 matrix coefficients.
+- PC applications/games that use sRGB (very common) are now tagged accurately if using sRGB. Video capture feeds that use 601/709 would not be, but we can leave behind 601/709 settings for passthrough scenarios. Actually converting the color data is beyond the scope of this RFC.
+- Chrome supports sRGB videos properly on all tested platforms.
+- Rec. 601 for output was almost always the wrong choice.
+
+Implementation:
+
+- Add VIDEO_CS_SRGB, and plumb into all switch cases.
+- Go through output encoder settings, and use sRGB metadata values.
+
+# Drawbacks
+
+People that had a working color pipeline with the old faulty settings may have to tweak their setup.
+
+There is supposedly a performance regression involving DeckLink when switching away from 601.
+
+# Additional Information
+
+None.


### PR DESCRIPTION
EDIT (2022-12-22): Current thinking is that there should be no color conversion between sRGB and Rec. 709. So a lot of what is stated on this RFC might be backwards. In particular, the test matrix entries for Good and Correct should be flipped. In any case, OBS is (mostly) doing the right thing (most of the time).

### Description
Add sRGB "Color Space" to output options, and possibly change default to sRGB.

### Motivation and Context
There is often confusion around the "Color Space" option for output, and it has several problems.

- We don't actually convert colors between RGB color spaces in OBS. We merely tag the metadata.
- Rec. 601 output support is weird. x264 tags 601 as "undef" for everything, and jim-nvenc uses the European 625-line variant of 601 attributes.
- Any PC applications/games that output sRGB are tagged as 601/709, and will be handled incorrectly by color-accurate applications, e.g. Chrome on Mac.

Adding and defaulting to sRGB is probably the least of all evils.

- sRGB is identical to Rec. 709 except for the sRGB transfer function, which can be a free conversion for most GPUs. When represented as YCbCr, it makes sense to transform with Rec. 709 matrix coefficients.
- PC applications/games that use sRGB (very common) are now tagged accurately if using sRGB. Video capture feeds that use 601/709 would not be, but we can leave behind 601/709 settings for passthrough scenarios. Actually converting the color data is beyond the scope of this RFC.
- Chrome supports sRGB videos properly on all tested platforms.
- Rec. 601 for output was almost always the wrong choice.

### [View the RFC](https://github.com/jpark37/rfcs/blob/color-space-sycc/accepted/0007-color-space-srgb.md)

### Test Matrix

| Platform | Application | 601 | 709 | sRGB (709 matrix) | Full | 480p |
| --- | --- | --- | --- | --- | --- | --- |
| Windows | Chrome | | Good (sRGB TRC) | Correct | Correct | |
| Windows | Firefox | | Good (sRGB TRC) | Correct | Bad | |
| Windows | VLC | | Good (sRGB TRC) | Correct | Bad | |
| Windows | Movies & TV | | Good (sRGB TRC) | Correct | | |
| Windows | Resolve | | Good (sRGB TRC) | Correct | | Bad (601 matrix) |
| Mac | Chrome | | Correct | Correct | Correct | | |
| Mac | Safari | | Correct | Correct | Correct | | |
| Android (Pixel XL) | Chrome | Good (709 prim.) | Bad (601 matrix) | Bad (601 matrix) | Bad | |
| Android (Pixel XL) | Twitch | Good (709 prim.) | Bad (601 matrix) | Bad (601 matrix) | Bad | |
| Android (Pixel XL) | VLC | | Bad (601 matrix) | Bad (601 matrix) | Bad | |
| Android (S9) | Chrome | Bad (709 matrix?) | Good (sRGB TRC) | Correct | Bad | |
| Android (S9) | Twitch | Bad (709 matrix?) | Good (sRGB TRC) | Correct | Bad | |
| iOS | Twitch | | Good (sRGB TRC) | Correct | Correct | |
| Twitch | (transcode) | | Correct (maybe) | Good (709 TRC) | Bad | |