### PR TITLE
Add RFC: Virtual Camera

### DIFF
--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -1,0 +1,42 @@
+- Start Date: 2020-03-25
+- RFC PR: #15
+- Related Github Issue: https://github.com/obsproject/obs-studio/issues/25685
+
+# Summary
+
+Add the ability to render output to a virtual camera device on Linux, Mac, and Windows.
+
+# Motivation
+
+OBS is a powerful set of tools to manipulate live video streams that natively supports output to popular streaming services as well as rendering to a local video file. There are a huge number of people who engage in 1:1 or small-scale streaming using video conferencing software like Zoom or Google Hangouts. Many of these people have similar needs to those of traditional streamers, but for one reason or another cannot switch the video conferencing software they use (social graph, corporate policy). One way to deliver OBS output to these applications is to provide a virtual camera in OBS.
+
+Similar functionality: 
+* OBS can be extended by the [OBS-VirtualCam plugin(https://obsproject.com/forum/resources/obs-virtualcam.539/)]. Currently, only Windows is supported.
+* [Wirecast includes virtual camera support](http://www.telestream.net/pdfs/user-guides/Wirecast-8-User-Guide-Windows.pdf) on both Windows and Mac.
+* [It was possible](https://github.com/zakk4223/SyphonInject) to inject Syphon functionality into a process that draws to a GL context until some Mac security changes broke this.
+* [The Snap Camera](https://snapcamera.snapchat.com) is an example of an application that consumes input from a hardware webcam, processes the video stream, and outputs it in real time as a virtual device that appears in apps like Skype, Hangouts, or Zoom. It supports both Mac & PC.
+
+# Detailed design
+- TODO - I don't know anything about OBS internals and so don't know how to design this.
+- Platform specific device driver?
+
+## Technical considerations
+
+- TODO
+
+## User UX
+
+- Add a button in the OBS UI below "Start Recording" and above "Studio Mode". In English localization, the button would be labeled "Start Virtual Camera".
+- When you click this button, the current output (either the preview output or the broadcast depending on studio mode) is directed to the Virtual Camera Device. The button text then toggles to the localized "Stop Virtual Camera" label.
+- When the user clicks into the settings of their video conferencing app, they will see an entry in the list of cameras labeled "OBS Virtual Camera" (or localized equivalent). When they choose this, the OBS output will be fed from this "device" to the app.
+- When the user clicks "Stop Virtual Camera", the virtual device no longer receives frames from OBS. It is up to the consuming application what to do in this state.
+
+# Drawbacks
+
+Specializing output to "virtual camera" is more maintenance load for OBS team, more complexity, and presumably, 3x complexity as the approach to create a virtual device probably involves a fair amount of platform-specific driver code. It's a very important case of video streaming with many millions of users, but it's still something of a special case.
+
+# Alternatives
+
+* Extend Mac & Linux OBS via plugin interface ala Windows-only OBS virtual camera. Clunkier, harder to use especially for novice users, but doesn't add as much complexity to base OBS.
+
+* Pursue a more generic output interface and (encourage someone else to?) build a generic virtual camera to consume it. E.g. output via RTSP, NDI and have a "NDI Cam" that has nothing to do with OBS.

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -33,6 +33,8 @@ Feature Set:
     * It informs the user that the output is not started yet, and needs to be started before output will be sent from OBS.
     * It is aesthetically pleasing such that, if the output is accidentally sent to viewers (for example, if the user fails to start the virtual output before joining a Zoom call), it is not unnecessarily gaudy or technical.
     * It requires minimal localization, or provides a way to localize any displayed text on the image
+* The auto-config tool is updated to include "outputting to a virtual camera" as their primary use case, with reasonable recommendations. Since this doesn't require testing encoding or bandwidth settings, the resolution should be set to 1920x1080 and frame rate set to 30FPS.
+* A new command line flag `--startvirtualcam` is added, which starts the virtual cam automatically when OBS is started.
 
 ## Platform specific implementations
 

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -38,7 +38,7 @@ Feature Set:
 
 ## Platform specific implementations
 
-* On **Windows**, the implementation of this plugin should leverage [libdshowcapture](https://github.com/obsproject/libdshowcapture). OBS already depends on libdshowcapture, so using this existing library service to limit the number of extra dependencies that OBS needs
+* On **Windows**, the implementation of this plugin should leverage [libdshowcapture](https://github.com/obsproject/libdshowcapture). OBS already depends on libdshowcapture, so using this existing library service limits the need to add additional dependecies.
 * On **macOS**, OBS will need a plugin to output over IPC to a CoreMediaIO DAL plugin that is registered on the system upon OBS install. This will require repackaging the installer as a `.pkg` instead of a compressed `.app`.
 * On **Linux**, the most straightforward way to implement this functionality would be to output via [v4l2sink](https://gstreamer.freedesktop.org/documentation/video4linux2/v4l2sink.html?gi-language=c). Note that this still requires the user to have [v4l2loopback](https://github.com/umlaeute/v4l2loopback) installed to consume this output. For package installations, a dependency should be placed on v4l2loopback such that it is installed by the package manager when OBS is installed.
 
@@ -46,12 +46,12 @@ Feature Set:
 
 - This RFC is explicitly for an OBS-specific implementation of output from OBS to a virtual camera. A generic middleware solution to this problem is out of scope for this problem.
 - The virtual camera will need to be registered with the system upon OBS installation.
-- The virtual camera should be accessible by third party applications that support webcams/capture cards
-- OBS supports running multiple instances of itself. If two instances of OBS run simultaneously, the first instance to output to the device should "win". The second instance should give an error saying that the output device is already in use by another instance of OBS.
+- The virtual camera should be accessible by third party applications that support webcams/capture cards.
+- OBS supports running multiple instances of itself. If two instances of OBS run simultaneously, the first instance to output to the device should "win" the race to communicate to the virtual camera device. The second instance should give an error saying that the output device is already in use by another instance of OBS, if possible.
 
 ## User UX
 
-* When installing, OBS should OBS should install the platform specific driver to enable virtual camera output on the system
+* When installing, OBS should install the platform specific driver to enable virtual camera output on the system
 * Initial configuration should require very little input from the user, if any. Resolution and framerate of the camera will be pre-defined by the Video settings of OBS, and no effects outside those already provided by OBS will be specially exposed for this output.
 * Add a button in the OBS UI below "Start Recording" and above "Studio Mode". In English localization, the button would be labeled "Start Virtual Camera".
 * When you click this button, the current output is directed to the virtual camera device. The button text then toggles to the localized "Stop Virtual Camera" label.

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -55,7 +55,7 @@ Each platform specific implementation will be separated into 2 cmake projects (s
 
 ## User UX
 
-- When installing OBS user should be asked if he would like to install the platform specific driver to enable virtual camera output on the system
+- When installing OBS should OBS should install the platform specific driver to enable virtual camera output on the system
 - Initial configuration should require very little input from the user, if any. Resolution and framerate of the camera will be pre-defined by the Video settings of OBS, and no effects outside those already provided by OBS will be specially exposed for this output.
 - Add a button in the OBS UI below "Start Recording" and above "Studio Mode". In English localization, the button would be labeled "Start Virtual Camera".
 - When you click this button, the current output (either the preview output or the broadcast depending on studio mode) is directed to the Virtual Camera Device. The button text then toggles to the localized "Stop Virtual Camera" label.

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -52,6 +52,7 @@ Each platform specific implementation will be separated into 2 cmake projects (s
 - A generic middleware solution to this problem is out of scope at the moment
 - A virtual camera needs to be registered with the system. Usually, this'll be done via the OBS installer/updater
 - The virtual device/output should be accessible by third party applications that support webcams/capture cards
+- OBS supports running multiple instances of itself. If an other instance is already running the virtual camera doesn't start a second virtual camera.
 
 ## User UX
 

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -8,64 +8,59 @@ Add the ability to render output to a virtual camera device on Linux, Mac, and W
 
 # Motivation
 
-OBS is a powerful set of tools to manipulate live video streams that natively supports output to popular streaming services as well as rendering to a local video file. There are a huge number of people who engage in 1:1 or small-scale streaming using video conferencing software like Zoom or Google Hangouts. Many of these people have similar needs to those of traditional streamers, but for one reason or another cannot switch the video conferencing software they use (social graph, corporate policy). One way to deliver OBS output to these applications is to provide a virtual camera in OBS.
+OBS is a powerful set of tools to manipulate live video streams that natively supports output to popular streaming services as well as rendering to a local video file. There are a huge number of people who engage in 1:1 or small-scale streaming using video conferencing software like Zoom or Google Hangouts. Many of these people have similar needs to those of traditional streamers, but for one reason or another cannot switch the video conferencing software they use (social graph, corporate policy).
+
+OBS can meet this need by creating a virtual camera device and outputting to that device such that programs capable of consuming camera input can now consume OBS input with no extra development.
 
 Similar functionality: 
-* OBS can be extended by the [OBS-VirtualCam plugin](https://obsproject.com/forum/resources/obs-virtualcam.539/). Currently, only Windows is supported.
+* OBS can be extended by the [OBS-VirtualCam plugin](https://obsproject.com/forum/resources/obs-virtualcam.539/) (Windows) and [obs-v4l2sink plugin](https://github.com/CatxFish/obs-v4l2sink). Currently, there is no OBS solution for macOS.
 * [Wirecast includes virtual camera support](http://www.telestream.net/pdfs/user-guides/Wirecast-8-User-Guide-Windows.pdf) on both Windows and Mac.
 * [It was possible](https://github.com/zakk4223/SyphonInject) to inject Syphon functionality into a process that draws to a GL context until some Mac security changes broke this.
 * [The Snap Camera](https://snapcamera.snapchat.com) is an example of an application that consumes input from a hardware webcam, processes the video stream, and outputs it in real time as a virtual device that appears in apps like Skype, Hangouts, or Zoom. It supports both Mac & PC.
 
 # Detailed design
 
-- Platform specific plugins shall be created that will be added as part of the main obs build.
-- Each plugin will start a server that will be responsible of transmitting the frame data to a client process.
-- A virtualcam "Driver" (client process) will be developed for each platform to consume data incomming from this plugins.
-- Each virtual driver shall be part of the installer with a checkbox to install the virtualcam driver
+Feature Set:
 
-## Cross-platform Interfaces
-
-We can define domain interfaces in order to maintain uniformity in the platform-specific plugins (maybe someday they will not be platform specific).
-
-- **OBSVirtualCamServer**: Interface that defines the set of methods to be implemented by a OBSVirtualCam Server in order to send and receive frame data (and other metadata) to the client processes.
-- **OBSVirtualCamClient**: Interface that defines the set of methods to be implemented by a OBSVirtualCam Client in order to register with a server(obs-studio) and receive frame data.
+* A button is added to the Output Controls dock labeled "Start Virtual Camera", which will toggle the start/stop status of the virtual camera output. While virtual camera output is active, the label should read 'Stop Virtual Camera".
+* The virtual camera appears in the system listed as "OBS Virtual Camera".
+* The virtual camera outputs at the same resolution and framerate as the OBS rendered output.
+* A section is added to OBS settings providing the following settings:
+    * A checkbox to indicate if the user wishes to start the virtual camera output automatically when OBS starts
+    * A checkbox to flip the virtual output horizontally
+* In the Output settings tab, the warning that appears when outputs are active is augmented to list all active outputs so that users know which outputs they need to disable in order to edit output settings.
+* When the virtual camera output is not active, the virtual camera device shows a static image to consumers indicating to the consumer that output is not started. This image meets four requirements:
+    * It allows the consumer to smoothly switch from non-active to active content without having to worry about what order the applications are started in.
+    * It informs the user that the output is not started yet, and needs to be started before output will be sent from OBS.
+    * It is aesthetically pleasing such that, if the output is accidentally sent to viewers (for example, if the user fails to start the virtual output before joining a Zoom call), it is not unnecessarily gaudy or technical.
+    * It requires minimal localization, or provides a way to localize any displayed text on the image
 
 ## Platform specific implementations
 
-Each platform specific implementation will be separated into 2 cmake projects (subprojects?).
-- **<Platform>OBSVirtualCam OBS Plugin**: Platform speficic obs plugin module that will be loaded by obs-studio in order to expose the virtual cam OBS Output and its controls. This will implement **OBSVirtualCamServer** and interfaces
-- **<Platform>OBSVirtualCam OBS Driver**: Platform specific driver code that will register the camera with the OS and will register with the **OBSVirtualCamServer** in order to receive data. If no connection to the server is available it should still register and render an static frame and keep waiting for the **OBSVirtualCamServer**. This will implement **OBSVirtualCamClient** interfaces.
-
-### Windows
-
-#### WindowsOBSVirtualCam OBS Module
-#### WindowsOBSVirtualCam Driver
-
-### Mac
-
-#### MacOBSVirtualCam OBS Module
-#### MacOBSVirtualCam Drivers
+* On **Windows**, the implementation of this plugin should leverage [libdshowcapture](https://github.com/obsproject/libdshowcapture). OBS already depends on libdshowcapture, so using this existing library service to limit the number of extra dependencies that OBS needs
+* On **macOS**, OBS will need a plugin to output over IPC to a CoreMediaIO DAL plugin that is registered on the system upon OBS install. This will require repackaging the installer as a `.pkg` instead of a compressed `.app`.
+* On **Linux**, the most straightforward way to implement this functionality would be to output via [v4l2sink](https://gstreamer.freedesktop.org/documentation/video4linux2/v4l2sink.html?gi-language=c). Note that this still requires the user to have [v4l2loopback](https://github.com/umlaeute/v4l2loopback) installed to consume this output. For package installations, a dependency should be placed on v4l2loopback such that it is installed by the package manager when OBS is installed.
 
 ## Technical considerations
 
-- This RFC is explicitly for an OBS-specific implementation of output from OBS to a virtual camera.
-- A generic middleware solution to this problem is out of scope at the moment
-- A virtual camera needs to be registered with the system. Usually, this'll be done via the OBS installer/updater
-- The virtual device/output should be accessible by third party applications that support webcams/capture cards
-- OBS supports running multiple instances of itself. If an other instance is already running the virtual camera doesn't start a second virtual camera.
+- This RFC is explicitly for an OBS-specific implementation of output from OBS to a virtual camera. A generic middleware solution to this problem is out of scope for this problem.
+- The virtual camera will need to be registered with the system upon OBS installation.
+- The virtual camera should be accessible by third party applications that support webcams/capture cards
+- OBS supports running multiple instances of itself. If two instances of OBS run simultaneously, the first instance to output to the device should "win". The second instance should give an error saying that the output device is already in use by another instance of OBS.
 
 ## User UX
 
-- When installing OBS should OBS should install the platform specific driver to enable virtual camera output on the system
-- Initial configuration should require very little input from the user, if any. Resolution and framerate of the camera will be pre-defined by the Video settings of OBS, and no effects outside those already provided by OBS will be specially exposed for this output.
-- Add a button in the OBS UI below "Start Recording" and above "Studio Mode". In English localization, the button would be labeled "Start Virtual Camera".
-- When you click this button, the current output (either the preview output or the broadcast depending on studio mode) is directed to the Virtual Camera Device. The button text then toggles to the localized "Stop Virtual Camera" label.
-- When the user clicks into the settings of their video conferencing app, they will see an entry in the list of cameras labeled "OBS Virtual Camera" (no localisation). When they choose this, the OBS output will be fed from this "device" to the app.
-- When the user clicks "Stop Virtual Camera", the virtual device no longer receives frames from OBS. It is up to the consuming application what to do in this state.
+* When installing, OBS should OBS should install the platform specific driver to enable virtual camera output on the system
+* Initial configuration should require very little input from the user, if any. Resolution and framerate of the camera will be pre-defined by the Video settings of OBS, and no effects outside those already provided by OBS will be specially exposed for this output.
+* Add a button in the OBS UI below "Start Recording" and above "Studio Mode". In English localization, the button would be labeled "Start Virtual Camera".
+* When you click this button, the current output is directed to the virtual camera device. The button text then toggles to the localized "Stop Virtual Camera" label.
+* When the user clicks into the settings of their video conferencing app, they will see an entry in the list of cameras labeled "OBS Virtual Camera" (no localization). When they choose this, the OBS output will be fed from this "device" to the app.
+* When the user clicks "Stop Virtual Camera", the virtual device no longer receives frames from OBS, and instead receives a static image defined by OBS indicating that the output is not active.
 
 # Drawbacks
 
-Platform-specific driver code would require maintenance as operating systems (especially in more recent times) tend to limit access (or require user permission) to access/provide to AV hardware. This especially will mean more testing/debugging will be required each time Windows, macOS, and officially supported Linux flavours (currently Ubuntu) provide a major update.
+* The most obvious omission from this RFC is the lack of virtual audio output in addition to virtual camera output. However, though the features are logically closely related, they are unfortunately vastly different technically speaking. As such, we will leave the implementation of virtual audio output to [a separate RFC](https://github.com/obsproject/rfcs/pull/16).
+* Platform-specific driver code would require maintenance as operating systems (especially in more recent times) tend to limit access (or require user permission) to access/provide to AV hardware. This especially will mean more testing/debugging will be required each time Windows, macOS, and officially supported Linux flavours (currently Ubuntu) provide a major update.
 
 # Alternatives
 

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -13,10 +13,9 @@ OBS is a powerful set of tools to manipulate live video streams that natively su
 OBS can meet this need by creating a virtual camera device and outputting to that device such that programs capable of consuming camera input can now consume OBS input with no extra development.
 
 Similar functionality: 
-* OBS can be extended by the [OBS-VirtualCam plugin](https://obsproject.com/forum/resources/obs-virtualcam.539/) (Windows) and [obs-v4l2sink plugin](https://github.com/CatxFish/obs-v4l2sink). Currently, there is no OBS solution for macOS.
+* OBS can be extended by the [OBS-VirtualCam plugin](https://obsproject.com/forum/resources/obs-virtualcam.539/) (Windows) and [obs-v4l2sink plugin](https://github.com/CatxFish/obs-v4l2sink) (Linux). Currently, there is no OBS solution for macOS.
 * [Wirecast includes virtual camera support](http://www.telestream.net/pdfs/user-guides/Wirecast-8-User-Guide-Windows.pdf) on both Windows and Mac.
-* [It was possible](https://github.com/zakk4223/SyphonInject) to inject Syphon functionality into a process that draws to a GL context until some Mac security changes broke this.
-* [The Snap Camera](https://snapcamera.snapchat.com) is an example of an application that consumes input from a hardware webcam, processes the video stream, and outputs it in real time as a virtual device that appears in apps like Skype, Hangouts, or Zoom. It supports both Mac & PC.
+* [Webcamoid](https://webcamoid.github.io/) is an existing open-source cross-platform virtual camera application, which may have some useful tidbits when investigating implementation details for each platform.
 
 # Detailed design
 
@@ -65,3 +64,4 @@ Feature Set:
 # Alternatives
 
 * Pursue a more generic output interface and (encourage someone else to?) build a generic virtual camera to consume it. E.g. output via RTSP, NDI and have a "NDI Cam" that has nothing to do with OBS.
+* Adapt Webcamoid's source code for our use. This may end up being more involved than we'd like, however, and might end up making the feature more complicated than we want.

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -11,7 +11,7 @@ Add the ability to render output to a virtual camera device on Linux, Mac, and W
 OBS is a powerful set of tools to manipulate live video streams that natively supports output to popular streaming services as well as rendering to a local video file. There are a huge number of people who engage in 1:1 or small-scale streaming using video conferencing software like Zoom or Google Hangouts. Many of these people have similar needs to those of traditional streamers, but for one reason or another cannot switch the video conferencing software they use (social graph, corporate policy). One way to deliver OBS output to these applications is to provide a virtual camera in OBS.
 
 Similar functionality: 
-* OBS can be extended by the [OBS-VirtualCam plugin(https://obsproject.com/forum/resources/obs-virtualcam.539/)]. Currently, only Windows is supported.
+* OBS can be extended by the [OBS-VirtualCam plugin](https://obsproject.com/forum/resources/obs-virtualcam.539/). Currently, only Windows is supported.
 * [Wirecast includes virtual camera support](http://www.telestream.net/pdfs/user-guides/Wirecast-8-User-Guide-Windows.pdf) on both Windows and Mac.
 * [It was possible](https://github.com/zakk4223/SyphonInject) to inject Syphon functionality into a process that draws to a GL context until some Mac security changes broke this.
 * [The Snap Camera](https://snapcamera.snapchat.com) is an example of an application that consumes input from a hardware webcam, processes the video stream, and outputs it in real time as a virtual device that appears in apps like Skype, Hangouts, or Zoom. It supports both Mac & PC.

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -28,7 +28,7 @@ Similar functionality:
 
 - Add a button in the OBS UI below "Start Recording" and above "Studio Mode". In English localization, the button would be labeled "Start Virtual Camera".
 - When you click this button, the current output (either the preview output or the broadcast depending on studio mode) is directed to the Virtual Camera Device. The button text then toggles to the localized "Stop Virtual Camera" label.
-- When the user clicks into the settings of their video conferencing app, they will see an entry in the list of cameras labeled "OBS Virtual Camera" (or localized equivalent). When they choose this, the OBS output will be fed from this "device" to the app.
+- When the user clicks into the settings of their video conferencing app, they will see an entry in the list of cameras labeled "OBS Virtual Camera" (no localisation). When they choose this, the OBS output will be fed from this "device" to the app.
 - When the user clicks "Stop Virtual Camera", the virtual device no longer receives frames from OBS. It is up to the consuming application what to do in this state.
 
 # Drawbacks

--- a/accepted/0015-virtual-camera-support.md
+++ b/accepted/0015-virtual-camera-support.md
@@ -17,15 +17,46 @@ Similar functionality:
 * [The Snap Camera](https://snapcamera.snapchat.com) is an example of an application that consumes input from a hardware webcam, processes the video stream, and outputs it in real time as a virtual device that appears in apps like Skype, Hangouts, or Zoom. It supports both Mac & PC.
 
 # Detailed design
-- TODO - I don't know anything about OBS internals and so don't know how to design this.
-- Platform specific device driver?
+
+- Platform specific plugins shall be created that will be added as part of the main obs build.
+- Each plugin will start a server that will be responsible of transmitting the frame data to a client process.
+- A virtualcam "Driver" (client process) will be developed for each platform to consume data incomming from this plugins.
+- Each virtual driver shall be part of the installer with a checkbox to install the virtualcam driver
+
+## Cross-platform Interfaces
+
+We can define domain interfaces in order to maintain uniformity in the platform-specific plugins (maybe someday they will not be platform specific).
+
+- **OBSVirtualCamServer**: Interface that defines the set of methods to be implemented by a OBSVirtualCam Server in order to send and receive frame data (and other metadata) to the client processes.
+- **OBSVirtualCamClient**: Interface that defines the set of methods to be implemented by a OBSVirtualCam Client in order to register with a server(obs-studio) and receive frame data.
+
+## Platform specific implementations
+
+Each platform specific implementation will be separated into 2 cmake projects (subprojects?).
+- **<Platform>OBSVirtualCam OBS Plugin**: Platform speficic obs plugin module that will be loaded by obs-studio in order to expose the virtual cam OBS Output and its controls. This will implement **OBSVirtualCamServer** and interfaces
+- **<Platform>OBSVirtualCam OBS Driver**: Platform specific driver code that will register the camera with the OS and will register with the **OBSVirtualCamServer** in order to receive data. If no connection to the server is available it should still register and render an static frame and keep waiting for the **OBSVirtualCamServer**. This will implement **OBSVirtualCamClient** interfaces.
+
+### Windows
+
+#### WindowsOBSVirtualCam OBS Module
+#### WindowsOBSVirtualCam Driver
+
+### Mac
+
+#### MacOBSVirtualCam OBS Module
+#### MacOBSVirtualCam Drivers
 
 ## Technical considerations
 
-- TODO
+- This RFC is explicitly for an OBS-specific implementation of output from OBS to a virtual camera.
+- A generic middleware solution to this problem is out of scope at the moment
+- A virtual camera needs to be registered with the system. Usually, this'll be done via the OBS installer/updater
+- The virtual device/output should be accessible by third party applications that support webcams/capture cards
 
 ## User UX
 
+- When installing OBS user should be asked if he would like to install the platform specific driver to enable virtual camera output on the system
+- Initial configuration should require very little input from the user, if any. Resolution and framerate of the camera will be pre-defined by the Video settings of OBS, and no effects outside those already provided by OBS will be specially exposed for this output.
 - Add a button in the OBS UI below "Start Recording" and above "Studio Mode". In English localization, the button would be labeled "Start Virtual Camera".
 - When you click this button, the current output (either the preview output or the broadcast depending on studio mode) is directed to the Virtual Camera Device. The button text then toggles to the localized "Stop Virtual Camera" label.
 - When the user clicks into the settings of their video conferencing app, they will see an entry in the list of cameras labeled "OBS Virtual Camera" (no localisation). When they choose this, the OBS output will be fed from this "device" to the app.
@@ -33,10 +64,8 @@ Similar functionality:
 
 # Drawbacks
 
-Specializing output to "virtual camera" is more maintenance load for OBS team, more complexity, and presumably, 3x complexity as the approach to create a virtual device probably involves a fair amount of platform-specific driver code. It's a very important case of video streaming with many millions of users, but it's still something of a special case.
+Platform-specific driver code would require maintenance as operating systems (especially in more recent times) tend to limit access (or require user permission) to access/provide to AV hardware. This especially will mean more testing/debugging will be required each time Windows, macOS, and officially supported Linux flavours (currently Ubuntu) provide a major update.
 
 # Alternatives
-
-* Extend Mac & Linux OBS via plugin interface ala Windows-only OBS virtual camera. Clunkier, harder to use especially for novice users, but doesn't add as much complexity to base OBS.
 
 * Pursue a more generic output interface and (encourage someone else to?) build a generic virtual camera to consume it. E.g. output via RTSP, NDI and have a "NDI Cam" that has nothing to do with OBS.


### PR DESCRIPTION
# Summary
Beginning of an RFC to add a Virtual Camera output to OBS

# Motivation
OBS is a powerful set of tools to manipulate live video streams that natively supports output to popular streaming services as well as rendering to a local video file. There are a huge number of people who engage in 1:1 or small-scale streaming using video conferencing software like Zoom or Google Hangouts. Many of these people have similar needs to those of traditional streamers, but for one reason or another cannot switch the video conferencing software they use (social graph, corporate policy). One way to deliver OBS output to these applications is to provide a virtual camera in OBS.

Similar functionality: 
* OBS can be extended by the [OBS-VirtualCam plugin](https://obsproject.com/forum/resources/obs-virtualcam.539/). Currently, only Windows is supported.
* [Wirecast includes virtual camera support](http://www.telestream.net/pdfs/user-guides/Wirecast-8-User-Guide-Windows.pdf) on both Windows and Mac.
* [It was possible](https://github.com/zakk4223/SyphonInject) to inject Syphon functionality into a process that draws to a GL context until some Mac security changes broke this.
* [The Snap Camera](https://snapcamera.snapchat.com) is an example of an application that consumes input from a hardware webcam, processes the video stream, and outputs it in real time as a virtual device that appears in apps like Skype, Hangouts, or Zoom. It supports both Mac & PC.

### [Read RFC](https://github.com/jebjeb/rfcs/blob/master/accepted/0015-virtual-camera-support.md)
