### PR TITLE
Add RFC: Add install python scripting support to installer

### DIFF
--- a/text/0037-Add-install-python-scripting-support-to-installer.md
+++ b/text/0037-Add-install-python-scripting-support-to-installer.md
@@ -1,0 +1,19 @@
+# Summary
+
+Add to the obs-studio windows installer the option to download and install python
+
+# Motivation
+
+It is often difficult to get python scripts working for regular users, due to needing to download a specific version of python, that is not easily found on the python site
+
+# Drawbacks
+
+Adds an extra step to the installer
+
+# Additional Information
+My thought is
+
+* Add a checkbox "Add Python Scripting Support"
+* If checked, download and install the correct python MSI
+* Add python path to the "python settings" config file
+* Yay! people can now more easily run python scripts on windows!!!


### PR DESCRIPTION
### Description 

 Add the option to `install python scripting support` to the windows installer
 
### Motivation and Context 

Ease the path for people using python scripts in OBS
# [Read RFC](https://github.com/cpyarger/rfcs/blob/rfc-0036/text/0037-Add-install-python-scripting-support-to-installer.md)
